### PR TITLE
BuildTool plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,9 +15,11 @@ let package = Package(
     ],
     products: [
         .executable(name: "swift-package-list", targets: ["SwiftPackageListCommand"]),
+        .executable(name: "SwiftPackageListCommand", targets: ["SwiftPackageListCommand"]),
         .library(name: "SwiftPackageList", targets: ["SwiftPackageList"]),
         .library(name: "SwiftPackageListObjc", type: .dynamic, targets: ["SwiftPackageListObjc"]),
         .library(name: "SwiftPackageListUI", targets: ["SwiftPackageListUI"]),
+        .plugin(name: "SwiftPackageListPlugin", targets: ["SwiftPackageListPlugin"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.1"),
@@ -56,6 +58,11 @@ let package = Package(
             name: "SwiftPackageListObjcTests",
             dependencies: ["SwiftPackageListObjc"],
             resources: [.process("Resources")]
+        ),
+        .plugin(
+            name: "SwiftPackageListPlugin",
+            capability: .buildTool(),
+            dependencies: [.target(name: "SwiftPackageListCommand")]
         ),
     ]
 )

--- a/Plugins/SwiftPackageListPlugin/FileManager+Extension.swift
+++ b/Plugins/SwiftPackageListPlugin/FileManager+Extension.swift
@@ -1,0 +1,15 @@
+//
+//  File.swift
+//  
+//
+//  Created by Dave Thompson on 16/03/2023.
+//
+
+import Foundation
+
+extension FileManager {
+    func createDirectoryIfNotExists(atPath path: String) throws {
+        guard !fileExists(atPath: path) else { return }
+        try createDirectory(atPath: path, withIntermediateDirectories: true)
+    }
+}

--- a/Plugins/SwiftPackageListPlugin/SwiftPackageListPlugin.swift
+++ b/Plugins/SwiftPackageListPlugin/SwiftPackageListPlugin.swift
@@ -1,0 +1,56 @@
+//
+//  File.swift
+//  swift-package-list
+//
+//  Created by Dave Thompson on 14/03/2023.
+//
+
+import Foundation
+import PackagePlugin
+
+@main struct Plugin: BuildToolPlugin {
+    func createBuildCommands(context: PackagePlugin.PluginContext,
+                             target: PackagePlugin.Target) async throws -> [PackagePlugin.Command] {
+        let projectFilePath = "\(context.package.directory)/\(context.package.displayName).xcodeproj"
+        let outputFilePath = try outputFilePath(workDirectory: context.pluginWorkDirectory)
+        return [
+            .buildCommand(
+                displayName: "SwiftPackageListPlugin",
+                executable: try context.tool(named: "SwiftPackageListCommand").path,
+                arguments: [projectFilePath, "--output-path", outputFilePath.removingLastComponent(), "--requires-license"],
+                outputFiles: [outputFilePath]
+            )
+        ]
+    }
+}
+
+extension Plugin {
+    private func outputFilePath(workDirectory: Path) throws -> Path {
+        let outputDirectory = workDirectory.appending("Output")
+        try FileManager.default.createDirectoryIfNotExists(atPath: outputDirectory.string)
+        return outputDirectory.appending("package-list.json")
+    }
+}
+
+#if canImport(XcodeProjectPlugin)
+    import XcodeProjectPlugin
+
+    extension Plugin: XcodeBuildToolPlugin {
+        /// This entry point is called when operating on an Xcode project
+        func createBuildCommands(context: XcodeProjectPlugin.XcodePluginContext,
+                                 target: XcodeProjectPlugin.XcodeTarget) throws -> [PackagePlugin.Command] {
+            let projectFilePath = "\(context.xcodeProject.directory)/\(target.displayName).xcodeproj"
+            let outputFilePath = try outputFilePath(workDirectory: context.pluginWorkDirectory)
+            return [
+                .buildCommand(
+                    displayName: "SwiftPackageListPlugin",
+                    executable: try context.tool(named: "SwiftPackageListCommand").path,
+                    arguments: [projectFilePath, "--output-path", outputFilePath.removingLastComponent(), "--requires-license"],
+                    outputFiles: [outputFilePath]
+                )
+            ]
+        }
+
+        
+    }
+#endif

--- a/Sources/SwiftPackageListCore/Output Generation/PDF/PDFGenerator.swift
+++ b/Sources/SwiftPackageListCore/Output Generation/PDF/PDFGenerator.swift
@@ -5,7 +5,16 @@
 //  Created by Felix Herrmann on 11.04.22.
 //
 
-import AppKit
+#if os(OSX)
+    import AppKit
+typealias AliasFont = NSFont
+typealias AliasEdgeInsets = NSEdgeInsets
+#elseif os(iOS)
+    import UIKit
+typealias AliasFont = UIFont
+typealias AliasEdgeInsets = UIEdgeInsets
+#endif
+
 import SwiftPackageList
 
 struct PDFGenerator: OutputGenerator {
@@ -67,10 +76,10 @@ struct PDFGenerator: OutputGenerator {
     }
     
     private func buildAttributedString() throws -> NSMutableAttributedString {
-        guard let defaultFont = NSFont(name: "Helvetica", size: 12) else {
+        guard let defaultFont = AliasFont(name: "Helvetica", size: 12) else {
             throw RuntimeError("Font \"Helvetica\" not available")
         }
-        guard let boldFont = NSFont(name: "Helvetica Bold", size: 12) else {
+        guard let boldFont = AliasFont(name: "Helvetica Bold", size: 12) else {
             throw RuntimeError("Font \"Helvetica Bold\" not available")
         }
         
@@ -112,7 +121,7 @@ struct PDFGenerator: OutputGenerator {
     
     private func calculateDrawableRect(in context: CGContext) -> CGRect {
         let boxRect = context.boundingBoxOfClipPath
-        let insets = NSEdgeInsets(top: 80, left: 80, bottom: 80, right: 80)
+        let insets = AliasEdgeInsets(top: 80, left: 80, bottom: 80, right: 80)
         
         let x = boxRect.origin.x + insets.left
         let y = boxRect.origin.y + insets.top

--- a/Sources/SwiftPackageListUI/SwiftUI/AcknowledgmentsList.swift
+++ b/Sources/SwiftPackageListUI/SwiftUI/AcknowledgmentsList.swift
@@ -8,6 +8,7 @@
 #if canImport(SwiftUI)
 
 import SwiftUI
+import SwiftPackageList
 
 /// A `List` that shows all licenses from the package-list file.
 ///
@@ -38,14 +39,16 @@ import SwiftUI
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public struct AcknowledgmentsList: View {
     
+    private var _title: Text?
     @ObservedObject private var _viewModel: _AcknowledgmentsListViewModel
     
     /// Creates a ``AcknowledgmentsList`` for a package-list file.
     /// - Parameters:
     ///   - packageListBundle: The bundle where the package-list file is stored. Default's to `Bundle.main`.
     ///   - packageListFileName: The name of the package-list file. Default's to `package-list`.
-    public init(packageListBundle: Bundle = .main, packageListFileName: String = "package-list") {
-        _viewModel = _AcknowledgmentsListViewModel(packageListBundle: packageListBundle, packageListFileName: packageListFileName)
+    public init(packageListBundle: Bundle = .main, packageListFileName: String = "package-list", otherPackages: [Package] = [], title: Text? = nil) {
+        _viewModel = _AcknowledgmentsListViewModel(packageListBundle: packageListBundle, packageListFileName: packageListFileName, otherPackages)
+        _title = title
     }
     
     public var body: some View {
@@ -60,7 +63,7 @@ public struct AcknowledgmentsList: View {
                 }
             }
         }
-        ._navigationTitle(Text("acknowledgments.title", bundle: .module, comment: "Navigation bar title of the license list"))
+        ._navigationTitle(_title ?? Text("acknowledgments.title", bundle: .module, comment: "Navigation bar title of the license list"))
     }
 }
 

--- a/Sources/SwiftPackageListUI/SwiftUI/_AcknowledgmentsListViewModel.swift
+++ b/Sources/SwiftPackageListUI/SwiftUI/_AcknowledgmentsListViewModel.swift
@@ -14,9 +14,10 @@ internal final class _AcknowledgmentsListViewModel: ObservableObject {
     
     @Published internal var _packages: [Package] = []
     
-    internal init(packageListBundle: Bundle, packageListFileName: String) {
+    internal init(packageListBundle: Bundle, packageListFileName: String, _ otherPackages: [Package] = []) {
         do {
             _packages = try packageList(bundle: packageListBundle, fileName: packageListFileName)
+            _packages.append(contentsOf: otherPackages)
         } catch {
             os_log(
                 "Error: %@",


### PR DESCRIPTION
This PR adds a new plugin product that that allows the executable to be run as a build tool in a package and in an XCode project.

Note: 
An additional executable product has been created because the plugin dependency name needs to be the same as the executable target due to the way the plugin build copies the executable targets into the build directory.

Updates to AcknowledmentsList allow usage of prebuilt swiftUI list to change the title and to append a list of additional license packages so we can manually add in licenses of dependencies not included by swift package manager